### PR TITLE
Correct the nano decimal amount recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Unrelated, do remember that Nano has harder work thresholds than Banano.
 
 ## Using for Nano instead of Banano
 
-The main differences between Nano and Banano; or at least those relevant to a library like this, are the different amount of decimals. So, when creating a `Wallet` with banani, make sure to do `my_rpc.DECIMALS = 31` otherwise your sends will be off by two magnitudes which is bad.
+The main differences between Nano and Banano; or at least those relevant to a library like this, are the different amount of decimals. So, when creating a `Wallet` with banani, make sure to do `rpc.DECIMALS = banani.NANO_DECIMALS` otherwise your sends will be off by two magnitudes which is bad.
 
 Also, a different preamble should be used for message signing.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Unrelated, do remember that Nano has harder work thresholds than Banano.
 
 ## Using for Nano instead of Banano
 
-The main differences between Nano and Banano; or at least those relevant to a library like this, are the different amount of decimals. So, when creating a `Wallet` with banani, make sure to do `rpc.DECIMALS = banani.NANO_DECIMALS` otherwise your sends will be off by two magnitudes which is bad.
+The main differences between Nano and Banano; or at least those relevant to a library like this, are the different amount of decimals. So, when creating a `Wallet` with banani, make sure to do `rpc.DECIMALS = banani.NANO_DECIMALS` otherwise your sends will be off by one magnitude which is bad.
 
 Also, a different preamble should be used for message signing.
 


### PR DESCRIPTION
Unless I'm misunderstanding what this was trying to convey, I'm pretty sure the decimal amount to use for nano is 30. And that corresponds with [the code](https://github.com/stjet/banani/blob/214f7b66650c827232ef8ce7aa7b4a26736a3f76/util.ts#L124-L125).

Wouldn't want someone to use the wrong value.