### PR TITLE
feat: generic argument for rpc.call

### DIFF
--- a/rpc.ts
+++ b/rpc.ts
@@ -35,7 +35,7 @@ export class RPC implements RPCInterface {
   //Network information related
 
   /** The function that sends the RPC POST request */
-  async call(payload: Record<string, any>): Promise<Record<string, any>> {
+  async call<T extends Record<string, any>>(payload: Record<string, any>): Promise<T> {
     if (this.debug) console.log(JSON.stringify(payload));
     const resp = await fetch(this.rpc_url, {
       method: "POST",


### PR DESCRIPTION
providing an optional generic for the `rpc.call` function to grant a user the ability to specify the expected return type.