### PR TITLE
Telemetry and version

### DIFF
--- a/rpc.ts
+++ b/rpc.ts
@@ -1,4 +1,4 @@
-import type { Address, BlockHash, BlockCountRPC, BlockInfoRPC, BlocksRPC, BlocksInfoRPC, RepresentativesRPC, RepresentativesOnlineRPC, RepresentativesOnlineWeightRPC, AccountHistoryRPC, AccountHistoryRawRPC, AccountInfoRPC, AccountBalanceRPC, AccountsBalancesRPC, AccountRepresentativeRPC, AccountsRepresentativesRPC, AccountWeightRPC, AccountReceivableRPC, AccountReceivableThresholdRPC, AccountReceivableSourceRPC, DelegatorsRPC, DelegatorsCountRPC } from "./rpc_types";
+import type { Address, BlockHash, BlockCountRPC, BlockInfoRPC, BlocksRPC, BlocksInfoRPC, RepresentativesRPC, RepresentativesOnlineRPC, RepresentativesOnlineWeightRPC, AccountHistoryRPC, AccountHistoryRawRPC, AccountInfoRPC, AccountBalanceRPC, AccountsBalancesRPC, AccountRepresentativeRPC, AccountsRepresentativesRPC, AccountWeightRPC, AccountReceivableRPC, AccountReceivableThresholdRPC, AccountReceivableSourceRPC, DelegatorsRPC, DelegatorsCountRPC, TelemetryRPC, TelemetryRawRPC, TelemetryAddressRPC, VersionRPC } from "./rpc_types";
 import { whole_to_raw } from "./util";
 
 /** Implement this interface if the built-in RPC class does not fit your needs. The easiest way to do this is by just extending the built-in RPC class */
@@ -180,6 +180,23 @@ export class RPC implements RPCInterface {
       action: "account_weight",
       account,
     })) as DelegatorsCountRPC;
+  }
+
+  /** https://docs.nano.org/commands/rpc-protocol/#telemetry */
+  async get_telemetry(raw?: boolean, address?: string, port?: number): Promise<TelemetryRPC | { metrics: TelemetryRawRPC[] } | TelemetryAddressRPC> {
+    return (await this.call({
+      action: "telemetry",
+      raw: raw ? raw : undefined,
+      address: address ? address : undefined,
+      port: port ? `${port}` : undefined,
+    })) as Promise<TelemetryRPC | { metrics: TelemetryRawRPC[] } | TelemetryAddressRPC>;
+  }
+
+  /** https://docs.nano.org/commands/rpc-protocol/#version */
+  async get_version(): Promise<VersionRPC> {
+    return (await this.call({
+      action: "version",
+    })) as VersionRPC;
   }
 }
 

--- a/rpc_types.ts
+++ b/rpc_types.ts
@@ -177,4 +177,45 @@ export interface DelegatorsCountRPC {
   count: `${number}`;
 }
 
+export interface TelemetryRPC {
+  block_count: `${number}`;
+  cemented_count: `${number}`;
+  unchecked_count: `${number}`;
+  account_count: `${number}`;
+  bandwidth_cap: `${number}`;
+  peer_count: `${number}`;
+  protocol_version: `${number}`;
+  uptime: `${number}`;
+  genesis_block: BlockHash;
+  major_version: `${number}`;
+  minor_version: `${number}`;
+  patch_version: `${number}`;
+  pre_release_version: `${number}`;
+  maker: string;
+  timestamp: `${number}`;
+  active_difficulty: `${number}`;
+  node_id: string;
+  signature: string;
+  network_identifier: string;
+}
+export interface TelemetryAddressRPC extends TelemetryRPC {
+  signature: string;
+  node_id: string;
+}
+export interface TelemetryRawRPC extends TelemetryAddressRPC {
+  address: string;
+  port: `${number}`;
+}
+
+export interface VersionRPC {
+  rpc_version: `${number}`;
+  store_version: `${number}`;
+  protocol_version: `${number}`;
+  node_vendor: string;
+  store_vendor: string;
+  network: string;
+  network_identifier: string;
+  build_info: string;
+}
+
 //


### PR DESCRIPTION
### New RPC Methods:
* Added `get_telemetry` method to fetch telemetry data, which can return different types of telemetry responses based on the parameters provided.
* Added `get_version` method to fetch the version information of the node.

### Type Definitions:
* Added `TelemetryRPC`, `TelemetryAddressRPC`, and `TelemetryRawRPC` interfaces to define the structure of telemetry data.
* Added `VersionRPC` interface to define the structure of version information.