### PR TITLE
added new function send_fixed_bal

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > ~~how to buy banani from beatrice~~
 > how to install banani on react.js
 
-Banani is a library for the Banano cryptocurrency that will support sending, receiving, changing rep, RPC calls, message signing, wallet management, etc. It aims to be a more powerful and sensible version of @bananocoin/bananojs. Banani takes heavy inspiration from the Python [bananopie](https://github.com/stjet/bananopie) (which I also wrote), which in turn takes some inspiration from my experiences with ethers.js.
+Banani is a library for the Banano cryptocurrency that will support sending, receiving, changing rep, RPC calls, message signing, wallet management, etc. It aims to be a more powerful and sensible version of @bananocoin/bananojs. Banani takes heavy inspiration from the Python [bananopie](https://github.com/stjet/bananopie) (which I [prussia] also wrote), which in turn takes some inspiration from my experiences with ethers.js.
 
 **Please report any bugs or request features by opening an Github issue.** You can ask for help or ask questions in the #frankensteins-lab channel of the Banano discord and people will be typically be eager to assist if they can.
 

--- a/wallet.ts
+++ b/wallet.ts
@@ -103,8 +103,7 @@ export class Wallet {
       if (info.representative === undefined) throw Error("Missing field 'representative' in `cached_account_info`");
       representative = info.representative;
     }
-    const new_balance = BigInt(raw_end);
-    if (new_balance < 0n) {
+    if (raw_end < 0n) {
       throw Error(`End balance cannot be negative`);
     }
     const block_ns: BlockNoSignature = {
@@ -112,7 +111,7 @@ export class Wallet {
       account: this.address,
       previous: info.frontier,
       representative,
-      balance: new_balance.toString() as `${number}`, //you gotta trust me here typescript
+      balance: raw_end.toString() as `${number}`, //you gotta trust me here typescript
       //link is public key of account to send to
       link: pub_receive,
       link_as_account: to,

--- a/wallet.ts
+++ b/wallet.ts
@@ -95,7 +95,7 @@ export class Wallet {
     return await this.send_process(block, "send");
   }
   /* Send by passing in a fixed final balance */
-  async send_fixed_bal(to: Address, end_bal: util.Whole, gen_work?: boolean, representative?: Address, cached_account_info?: AccountInfoRPC): Promise<BlockHash> {
+  async send_fixed_final_bal(to: Address, end_bal: util.Whole, gen_work?: boolean, representative?: Address, cached_account_info?: AccountInfoRPC): Promise<BlockHash> {
     const raw_end = util.whole_to_raw(end_bal, this.rpc.DECIMALS);
     const info = cached_account_info ?? (await this.get_account_info(undefined, true)); //this should be lazy. the true makes sure representative is included
     const pub_receive = util.get_public_key_from_address(to);

--- a/wallet.ts
+++ b/wallet.ts
@@ -94,6 +94,36 @@ export class Wallet {
     const block = { ...block_ns, signature, work };
     return await this.send_process(block, "send");
   }
+  /* Send by passing in a fixed final balance */
+  async send_fixed_bal(to: Address, end_bal: util.Whole, gen_work?: boolean, representative?: Address, cached_account_info?: AccountInfoRPC): Promise<BlockHash> {
+    const raw_end = util.whole_to_raw(end_bal, this.rpc.DECIMALS);
+    const info = cached_account_info ?? (await this.get_account_info(undefined, true)); //this should be lazy. the true makes sure representative is included
+    const pub_receive = util.get_public_key_from_address(to);
+    if (representative === undefined) {
+      if (info.representative === undefined) throw Error("Missing field 'representative' in `cached_account_info`");
+      representative = info.representative;
+    }
+    const new_balance = BigInt(raw_end);
+    if (new_balance < 0n) {
+      throw Error(`End balance cannot be negative`);
+    }
+    const block_ns: BlockNoSignature = {
+      type: "state",
+      account: this.address,
+      previous: info.frontier,
+      representative,
+      balance: new_balance.toString() as `${number}`, //you gotta trust me here typescript
+      //link is public key of account to send to
+      link: pub_receive,
+      link_as_account: to,
+    };
+    const s_block_hash = util.hash_block(block_ns); //block hash of the send block
+    let work = undefined;
+    if (gen_work && this.work_function) work = await this.work_function(info.frontier);
+    const signature = util.sign_block_hash(this.private_key, s_block_hash);
+    const block = { ...block_ns, signature, work };
+    return await this.send_process(block, "send");
+  }
   /* Send all Bananos */
   async send_all(to: Address, work?: boolean, representative?: Address): Promise<BlockHash> {
     const info = await this.get_account_info(undefined, true);


### PR DESCRIPTION
In an attempt to thwart possible double-sends, we may define an ending balance for the new block instead of calculating it on the fly. This MAY introduce the possibility of less-than-requested sends, but in theory, it can protect against malicious actors calling the send function successively.